### PR TITLE
Update FMP.ipynb

### DIFF
--- a/fingpt/FinGPT-v2/data_preparations/FMP.ipynb
+++ b/fingpt/FinGPT-v2/data_preparations/FMP.ipynb
@@ -1265,7 +1265,7 @@
     "        if len(res) == 0:\n",
     "            break\n",
     "        else:\n",
-    "            res = pd.DataFrame(res)\n",
+    "            res = pd.DataFrame(res,index=[0])\n",
     "            all = pd.concat([all, res])"
    ]
   },


### PR DESCRIPTION
Unable to run FMP.ipynb because of error ValueError: If using all scalar values, you must pass an index
this commit will fix this error