### PR TITLE
remove api key even if disabled

### DIFF
--- a/fingpt/chatgpt-trading-v2/openai_token/token_.py
+++ b/fingpt/chatgpt-trading-v2/openai_token/token_.py
@@ -1,2 +1,2 @@
 
-OPEN_AI_TOKEN = "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"
+OPEN_AI_TOKEN = "your-api-token"


### PR DESCRIPTION
While exposed api token was disabled ( #24 ). I think it should be removed so that people don't open issues or try using it.
This merge request remove the api token and replace it with `your-api-token`.