### PR TITLE
Allow benchmarking on CPU

### DIFF
--- a/fingpt/FinGPT_Benchmark/benchmarks/fiqa.py
+++ b/fingpt/FinGPT_Benchmark/benchmarks/fiqa.py
@@ -87,7 +87,7 @@ def test_fiqa(args, model, tokenizer, prompt_fun=add_instructions):
         tokens = tokenizer(tmp_context, return_tensors='pt', padding=True, max_length=512, return_token_type_ids=False)
         # tokens.pop('token_type_ids')
         for k in tokens.keys():
-            tokens[k] = tokens[k].cuda()
+            tokens[k] = tokens[k].to(model.device)
         
         res = model.generate(**tokens, max_length=512, eos_token_id=tokenizer.eos_token_id)
         res_sentences = [tokenizer.decode(i, skip_special_tokens=True) for i in res]

--- a/fingpt/FinGPT_Benchmark/benchmarks/fpb.py
+++ b/fingpt/FinGPT_Benchmark/benchmarks/fpb.py
@@ -82,7 +82,7 @@ def test_fpb(args, model, tokenizer, prompt_fun=None):
         tmp_context = context[i* batch_size:(i+1)* batch_size]
         tokens = tokenizer(tmp_context, return_tensors='pt', padding=True, max_length=512, return_token_type_ids=False)
         for k in tokens.keys():
-            tokens[k] = tokens[k].cuda()
+            tokens[k] = tokens[k].to(model.device)
         res = model.generate(**tokens, max_length=512, eos_token_id=tokenizer.eos_token_id)
         res_sentences = [tokenizer.decode(i, skip_special_tokens=True) for i in res]
         # print(f'{i}: {res_sentences[0]}')

--- a/fingpt/FinGPT_Benchmark/benchmarks/nwgi.py
+++ b/fingpt/FinGPT_Benchmark/benchmarks/nwgi.py
@@ -65,7 +65,7 @@ def test_nwgi(args, model, tokenizer, prompt_fun=None):
         tokens = tokenizer(tmp_context, return_tensors='pt', padding=True, max_length=512, return_token_type_ids=False)
         # tokens.pop('token_type_ids')
         for k in tokens.keys():
-            tokens[k] = tokens[k].cuda()
+            tokens[k] = tokens[k].to(model.device)
         res = model.generate(**tokens, max_length=512, eos_token_id=tokenizer.eos_token_id)
         res_sentences = [tokenizer.decode(i, skip_special_tokens=True) for i in res]
         out_text = [o.split("Answer: ")[1] for o in res_sentences]

--- a/fingpt/FinGPT_Benchmark/benchmarks/tfns.py
+++ b/fingpt/FinGPT_Benchmark/benchmarks/tfns.py
@@ -61,7 +61,7 @@ def test_tfns(args, model, tokenizer, prompt_fun=None):
         tokens = tokenizer(tmp_context, return_tensors='pt', padding=True, max_length=512, return_token_type_ids=False)
         # tokens.pop('token_type_ids')
         for k in tokens.keys():
-            tokens[k] = tokens[k].cuda()
+            tokens[k] = tokens[k].to(model.device)
         res = model.generate(**tokens, max_length=512, eos_token_id=tokenizer.eos_token_id)
         res_sentences = [tokenizer.decode(i, skip_special_tokens=True) for i in res]
         out_text = [o.split("Answer: ")[1] for o in res_sentences]


### PR DESCRIPTION
In CI pipelines and testing suites, it is common for test code to run tiny toy models on the CPU to make sure things work before running a full model on accelerators. I found that a few benchmarks were hard coded to use CUDA and causes such tests to fail. I've updated the benchmarks so that they move data to the device the model itself is on.