### PR TITLE
Fix Hugging Face Hub timeout issues in PEFT model loading

### DIFF
--- a/fingpt/FinGPT_Benchmark/benchmarks/benchmarks.py
+++ b/fingpt/FinGPT_Benchmark/benchmarks/benchmarks.py
@@ -2,10 +2,11 @@ from transformers import AutoTokenizer, AutoModelForCausalLM
 from peft import PeftModel, get_peft_model, LoraConfig, TaskType  # 0.4.0
 import torch
 import argparse
+import os
 
 
 from fpb import test_fpb, test_fpb_mlt
-from fiqa import test_fiqa, test_fiqa_mlt 
+from fiqa import test_fiqa, test_fiqa_mlt
 from tfns import test_tfns
 from nwgi import test_nwgi
 from headline import test_headline
@@ -14,6 +15,9 @@ from convfinqa import test_convfinqa
 from fineval import test_fineval
 from finred import test_re
 
+
+# Increase HuggingFace Hub timeout to handle slow network connections or large file downloads
+os.environ.setdefault("HF_HUB_TIMEOUT", "120")
 
 import sys
 sys.path.append('../')

--- a/fingpt/FinGPT_Forecaster/app.py
+++ b/fingpt/FinGPT_Forecaster/app.py
@@ -14,6 +14,8 @@ from collections import defaultdict
 from datetime import date, datetime, timedelta
 from transformers import AutoTokenizer, AutoModelForCausalLM, TextStreamer
 
+# Increase HuggingFace Hub timeout to handle slow network connections or large file downloads
+os.environ.setdefault("HF_HUB_TIMEOUT", "120")
 
 access_token = os.environ["HF_TOKEN"]
 finnhub_client = finnhub.Client(api_key=os.environ["FINNHUB_API_KEY"])

--- a/finogrid/fingpt_integration/sentiment/crypto_sentiment.py
+++ b/finogrid/fingpt_integration/sentiment/crypto_sentiment.py
@@ -8,11 +8,15 @@ NOT used in the hot transaction path — runs asynchronously.
 """
 from __future__ import annotations
 
+import os
 import structlog
 from typing import Optional
 from transformers import AutoTokenizer, AutoModelForCausalLM, pipeline
 from peft import PeftModel
 import torch
+
+# Increase HuggingFace Hub timeout to handle slow network connections or large file downloads
+os.environ.setdefault("HF_HUB_TIMEOUT", "120")
 
 log = structlog.get_logger()
 


### PR DESCRIPTION
Fixes #161: Increase HF_HUB_TIMEOUT from default 10s to 120s

The Hugging Face app was experiencing ReadTimeout errors when loading PEFT adapters from Hugging Face Hub due to the default 10-second timeout being too short for downloading large model weights, especially over slow network connections.

This fix sets HF_HUB_TIMEOUT environment variable to 120 seconds in all files that load PEFT models:
- fingpt/FinGPT_Forecaster/app.py
- fingpt/FinGPT_Benchmark/benchmarks/benchmarks.py
- finogrid/fingpt_integration/sentiment/crypto_sentiment.py