### PR TITLE
fix: pin bitsandbytes and add missing deps for HuggingFace Forecaster demo

### DIFF
--- a/fingpt/FinGPT_Forecaster/requirements.txt
+++ b/fingpt/FinGPT_Forecaster/requirements.txt
@@ -1,6 +1,9 @@
 torch==2.0.1
 transformers==4.32.0
 peft==0.5.0
+bitsandbytes==0.41.1
+accelerate==0.23.0
+gradio==3.50.2
 pandas
 yfinance
 finnhub-python


### PR DESCRIPTION
## Summary

Pin dependency versions in the FinGPT Forecaster HuggingFace Space demo to fix the runtime crash caused by incompatible `bitsandbytes` and `triton` versions.

Fixes #205

## Problem

The `requirements.txt` for `fingpt/FinGPT_Forecaster` does not pin `bitsandbytes` or `triton`. When HuggingFace installs dependencies, it resolves to latest versions where `bitsandbytes` >=0.42 tries to import `triton.runtime.driver` — which was removed in newer `triton` releases — producing:

```
ImportError: cannot import name 'driver' from 'triton.runtime'
```

Additionally, `gradio` and `accelerate` are used by `app.py` but were never listed in `requirements.txt`.

## Changes

- Pin `bitsandbytes==0.41.1` (last stable version before triton-dependent code path)
- - Add `accelerate==0.23.0` (required by `peft` for `device_map="auto"`)
- - Add `gradio==3.50.2` (used by `app.py` but previously missing)
## Testing

- Verified import chain: `peft==0.5.0` → `bitsandbytes==0.41.1` does not trigger the `triton.runtime.driver` import
- - All pinned versions are compatible with `torch==2.0.1` and `transformers==4.32.0`