### PR TITLE
Add multi-agent financial news analysis notebook

### DIFF
--- a/fingpt/ag2_financial_analysis_pipeline.ipynb
+++ b/fingpt/ag2_financial_analysis_pipeline.ipynb
@@ -1,0 +1,234 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Multi-Agent Financial News Analysis Pipeline\n",
+    "\n",
+    "Financial analysts spend hours reading news, assessing sentiment, and synthesizing findings into actionable insights. In this notebook, we build an automated pipeline where multiple AI agents collaborate to do this work — fetching financial news, running sentiment analysis with FinGPT models, and producing a structured investment brief.\n",
+    "\n",
+    "We use [AG2](https://ag2.ai) to orchestrate three specialized agents:\n",
+    "- A **News Researcher** that gathers and summarizes recent financial news for a given ticker\n",
+    "- A **Sentiment Analyst** that runs FinGPT sentiment classification on the headlines\n",
+    "- An **Investment Advisor** that synthesizes findings into an actionable brief\n",
+    "\n",
+    "Each agent has access to real tools and works with live data from the Hugging Face Hub and financial APIs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install \"ag2[openai]>=0.11.4,<1.0\" huggingface_hub transformers torch yfinance -q"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Connecting to a Language Model\n",
+    "\n",
+    "We power our agents with an open-source model via the Hugging Face Inference API, which provides an OpenAI-compatible endpoint. You'll need a [HF token](https://huggingface.co/settings/tokens)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\nfrom huggingface_hub import get_token\nfrom autogen import AssistantAgent, UserProxyAgent, GroupChat, GroupChatManager, LLMConfig\n\nhf_token = get_token()\n\nllm_config = LLMConfig({\n    \"model\": \"Qwen/Qwen2.5-Coder-32B-Instruct\",\n    \"api_key\": hf_token,\n    \"api_type\": \"openai\",\n    \"base_url\": \"https://router.huggingface.co/v1\",\n})"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Building the Financial Analysis Tools\n",
+    "\n",
+    "Before creating agents, we give them tools to work with real financial data:\n",
+    "\n",
+    "1. **get_stock_info** — fetch recent price data and key metrics for a ticker using `yfinance`\n",
+    "2. **get_financial_news** — retrieve recent news headlines for a company via `yfinance`\n",
+    "3. **analyze_sentiment** — run FinGPT-style sentiment classification on financial text using a HuggingFace model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import json\nfrom typing import Annotated\nfrom datetime import datetime, timedelta\n\nimport yfinance as yf\n\n\ndef get_stock_info(\n    ticker: Annotated[str, \"Stock ticker symbol, e.g. 'AAPL', 'MSFT', 'GOOGL'\"],\n) -> str:\n    \"\"\"Fetch recent stock price data and key financial metrics.\"\"\"\n    try:\n        stock = yf.Ticker(ticker)\n        info = stock.info\n\n        # Get recent price history\n        hist = stock.history(period=\"1mo\")\n        if hist.empty:\n            return json.dumps({\"error\": f\"No price data found for {ticker}\"})\n\n        current_price = hist[\"Close\"].iloc[-1]\n        month_ago_price = hist[\"Close\"].iloc[0]\n        price_change_pct = ((current_price - month_ago_price) / month_ago_price) * 100\n\n        result = {\n            \"ticker\": ticker,\n            \"company_name\": info.get(\"longName\", ticker),\n            \"sector\": info.get(\"sector\", \"unknown\"),\n            \"current_price\": round(current_price, 2),\n            \"price_change_1mo_pct\": round(price_change_pct, 2),\n            \"market_cap\": info.get(\"marketCap\", \"N/A\"),\n            \"pe_ratio\": info.get(\"trailingPE\", \"N/A\"),\n            \"52w_high\": info.get(\"fiftyTwoWeekHigh\", \"N/A\"),\n            \"52w_low\": info.get(\"fiftyTwoWeekLow\", \"N/A\"),\n        }\n        return json.dumps(result, indent=2)\n    except Exception as e:\n        return json.dumps({\"error\": str(e)})\n\n\ndef get_financial_news(\n    ticker: Annotated[str, \"Stock ticker symbol\"],\n    max_headlines: Annotated[int, \"Maximum number of headlines to return\"] = 10,\n) -> str:\n    \"\"\"Get recent financial news headlines for a stock ticker.\"\"\"\n    try:\n        stock = yf.Ticker(ticker)\n        news = stock.news\n\n        if not news:\n            return json.dumps({\"ticker\": ticker, \"headlines\": [], \"message\": \"No recent news found\"})\n\n        headlines = []\n        for item in news[:max_headlines]:\n            content = item.get(\"content\", item)\n            provider = content.get(\"provider\", {})\n            pub_date = content.get(\"pubDate\", \"\")\n            headlines.append({\n                \"title\": content.get(\"title\", \"\"),\n                \"publisher\": provider.get(\"displayName\", \"\"),\n                \"published\": pub_date[:10] if pub_date else \"unknown\",\n            })\n\n        return json.dumps({\"ticker\": ticker, \"headlines\": headlines}, indent=2)\n    except Exception as e:\n        return json.dumps({\"error\": str(e)})\n\n\ndef analyze_sentiment(\n    texts: Annotated[list[str], \"List of financial text snippets to analyze (headlines, summaries, etc.)\"],\n) -> str:\n    \"\"\"Run sentiment analysis on financial texts using a FinGPT-aligned model.\n\n    Uses a financial sentiment model from HuggingFace to classify each text\n    as positive, negative, or neutral with confidence scores.\n    \"\"\"\n    from transformers import pipeline\n\n    # Use a financial sentiment model — ProsusAI/finbert is well-established\n    # and aligns with FinGPT's sentiment analysis focus\n    try:\n        classifier = pipeline(\n            \"sentiment-analysis\",\n            model=\"ProsusAI/finbert\",\n            return_all_scores=False,\n        )\n\n        results = []\n        for text in texts:\n            pred = classifier(text[:512])[0]  # Truncate to model max length\n            results.append({\n                \"text\": text[:100] + (\"...\" if len(text) > 100 else \"\"),\n                \"sentiment\": pred[\"label\"],\n                \"confidence\": round(pred[\"score\"], 4),\n            })\n\n        # Aggregate summary\n        sentiments = [r[\"sentiment\"] for r in results]\n        summary = {\n            \"positive\": sentiments.count(\"positive\"),\n            \"negative\": sentiments.count(\"negative\"),\n            \"neutral\": sentiments.count(\"neutral\"),\n            \"total\": len(results),\n        }\n\n        return json.dumps({\"results\": results, \"summary\": summary}, indent=2)\n    except Exception as e:\n        return json.dumps({\"error\": str(e)})"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating the Agent Team\n",
+    "\n",
+    "Each agent has a focused role and access to specific tools:\n",
+    "\n",
+    "- **News Researcher** — fetches stock data and news, builds a factual overview\n",
+    "- **Sentiment Analyst** — runs FinGPT-style sentiment classification on the headlines\n",
+    "- **Investment Advisor** — synthesizes everything into a structured brief with a recommendation\n",
+    "\n",
+    "We use AG2's decorator pattern to register which agent can call which tool."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "researcher = AssistantAgent(\n    name=\"News_Researcher\",\n    system_message=(\n        \"You are a financial news researcher. Your job is to gather data about \"\n        \"the requested stock ticker. Use get_stock_info to fetch price and metrics, \"\n        \"then use get_financial_news to get recent headlines. \"\n        \"Present your findings clearly: company overview, recent price action, \"\n        \"and a numbered list of the most relevant headlines. \"\n        \"Only use the tools provided — do not make up data.\"\n    ),\n    llm_config=llm_config,\n)\n\nanalyst = AssistantAgent(\n    name=\"Sentiment_Analyst\",\n    system_message=(\n        \"You are a financial sentiment analyst specializing in NLP-based analysis. \"\n        \"When the News Researcher has gathered headlines, use analyze_sentiment \"\n        \"to run sentiment classification on those headlines. \"\n        \"Present results in a structured table showing each headline, its sentiment \"\n        \"(positive/negative/neutral), and confidence score. \"\n        \"Provide an overall sentiment summary. \"\n        \"Only use the tools provided — do not invent scores.\"\n    ),\n    llm_config=llm_config,\n)\n\nadvisor = AssistantAgent(\n    name=\"Investment_Advisor\",\n    system_message=(\n        \"You are an investment advisor. Based on the News Researcher's data and \"\n        \"the Sentiment Analyst's classification results, produce a structured \"\n        \"investment brief. Include:\\n\"\n        \"1. Company snapshot (price, metrics, sector)\\n\"\n        \"2. News sentiment summary (% positive/negative/neutral)\\n\"\n        \"3. Key risks and catalysts identified from the news\\n\"\n        \"4. Overall outlook (bullish/bearish/neutral) with reasoning\\n\\n\"\n        \"IMPORTANT: Add a disclaimer that this is AI-generated analysis, not \"\n        \"financial advice. End your brief with TERMINATE.\"\n    ),\n    llm_config=llm_config,\n)\n\nexecutor = UserProxyAgent(\n    name=\"Executor\",\n    human_input_mode=\"NEVER\",\n    max_consecutive_auto_reply=10,\n    code_execution_config=False,\n)\n\n# Register tools — Researcher and Analyst can call them, Executor runs them\nfor tool_fn, description in [\n    (get_stock_info, \"Fetch recent stock price data and key financial metrics for a ticker\"),\n    (get_financial_news, \"Get recent financial news headlines for a stock ticker\"),\n    (analyze_sentiment, \"Run sentiment analysis on a list of financial text snippets\"),\n]:\n    executor.register_for_execution()(tool_fn)\n    researcher.register_for_llm(description=description)(tool_fn)\n    analyst.register_for_llm(description=description)(tool_fn)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Running the Pipeline\n",
+    "\n",
+    "Let's analyze a stock. The GroupChat manager coordinates the agents — the Researcher gathers data first, the Analyst runs sentiment classification, and the Advisor wraps up with a structured brief."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "group_chat = GroupChat(\n",
+    "    agents=[executor, researcher, analyst, advisor],\n",
+    "    messages=[],\n",
+    "    max_round=10,\n",
+    "    speaker_selection_method=\"auto\",\n",
+    ")\n",
+    "\n",
+    "manager = GroupChatManager(\n",
+    "    groupchat=group_chat,\n",
+    "    llm_config=llm_config,\n",
+    ")\n",
+    "\n",
+    "executor.run(\n",
+    "    manager,\n",
+    "    message=(\n",
+    "        \"Analyze NVDA (NVIDIA). Fetch the latest stock data and news headlines, \"\n",
+    "        \"run sentiment analysis on the headlines, and produce an investment brief \"\n",
+    "        \"with an overall outlook.\"\n",
+    "    ),\n",
+    ").process()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reviewing the Agent Conversation\n",
+    "\n",
+    "Let's trace how the agents collaborated — who spoke, what tools they called, and how the analysis was built step by step:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for msg in group_chat.messages:\n",
+    "    name = msg.get(\"name\", msg.get(\"role\", \"unknown\"))\n",
+    "    content = msg.get(\"content\", \"\")\n",
+    "    if content and content.strip():\n",
+    "        print(f\"{'='*60}\")\n",
+    "        print(f\">> {name}:\")\n",
+    "        print(f\"{content[:800]}\")\n",
+    "        print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Try It Yourself\n",
+    "\n",
+    "Change the ticker and question below to analyze any stock:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Change this to any ticker you want to analyze!\n",
+    "your_ticker = \"TSLA\"\n",
+    "your_question = (\n",
+    "    f\"Analyze {your_ticker}. Fetch stock data and recent news, \"\n",
+    "    f\"run sentiment analysis on the headlines, and produce an \"\n",
+    "    f\"investment brief with an overall outlook and key risks.\"\n",
+    ")\n",
+    "\n",
+    "group_chat_2 = GroupChat(\n",
+    "    agents=[executor, researcher, analyst, advisor],\n",
+    "    messages=[],\n",
+    "    max_round=10,\n",
+    "    speaker_selection_method=\"auto\",\n",
+    ")\n",
+    "\n",
+    "manager_2 = GroupChatManager(groupchat=group_chat_2, llm_config=llm_config)\n",
+    "executor.run(manager_2, message=your_question).process()\n",
+    "\n",
+    "# Print the advisor's brief\n",
+    "for msg in reversed(group_chat_2.messages):\n",
+    "    if msg.get(\"name\") == \"Investment_Advisor\" and msg.get(\"content\", \"\").strip():\n",
+    "        print(\"Investment Brief:\")\n",
+    "        print(msg[\"content\"].replace(\"TERMINATE\", \"\").strip())\n",
+    "        break"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What We Built\n",
+    "\n",
+    "This notebook demonstrated a practical financial analysis pipeline where:\n",
+    "\n",
+    "1. **The News Researcher** fetched real-time stock data and news via `yfinance`\n",
+    "2. **The Sentiment Analyst** ran FinGPT-style sentiment classification on headlines using FinBERT from HuggingFace\n",
+    "3. **The Investment Advisor** synthesized data + sentiment into a structured investment brief\n",
+    "\n",
+    "Each agent has a focused role with access to real tools — they call live APIs, run actual ML inference, and work with real market data.\n",
+    "\n",
+    "**Extending this pattern:**\n",
+    "- Swap FinBERT for a FinGPT fine-tuned model (e.g., `FinGPT/fingpt-sentiment_llama2-13b_lora`) for potentially better financial sentiment accuracy\n",
+    "- Add a **Risk Manager** agent that cross-references sentiment with volatility metrics\n",
+    "- Add an **SEC Filings** tool to pull 10-K/10-Q data for fundamental analysis\n",
+    "- Connect to the [FinGPT Forecaster](https://huggingface.co/FinGPT/fingpt-forecaster_dow30_llama2-7b_lora) for price movement predictions\n",
+    "- Run the pipeline on a portfolio of tickers for batch analysis\n",
+    "\n",
+    "For more on multi-agent orchestration patterns, see the [AG2 documentation](https://docs.ag2.ai)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

- Adds a notebook demonstrating multi-agent financial analysis using [AG2](https://ag2.ai) for agent orchestration, `yfinance` for market data, and FinBERT for sentiment classification
- Three specialized agents collaborate: **News Researcher** (fetches stock data + news), **Sentiment Analyst** (runs NLP sentiment on headlines), **Investment Advisor** (produces structured brief)
- Automates the workflow analysts do manually — gathering news, classifying sentiment, producing a summary — with real tools and live data

## Test plan

- [x] All three tools tested individually (`get_stock_info`, `get_financial_news`, `analyze_sentiment`)
- [x] Full end-to-end pipeline tested with NVDA ticker — all agents executed their roles correctly
- [x] Verified AG2 v0.11.4 API patterns (LLMConfig, tool registration, GroupChat, run/process)
- [x] Notebook is valid JSON, single file addition, no changes to existing code

## Files

- `fingpt/ag2_financial_analysis_pipeline.ipynb` — single notebook, no changes to existing code