### PR TITLE
feat: add optional Adanos market sentiment to FinGPT-Forecaster

### DIFF
--- a/fingpt/FinGPT_Forecaster/README.md
+++ b/fingpt/FinGPT_Forecaster/README.md
@@ -17,12 +17,13 @@ Enter the following inputs:
 2) the day from which you want the prediction to happen (yyyy-mm-dd)
 3) the number of past weeks where market news are retrieved
 4) whether to add latest basic financials as additional information
+5) whether to add optional structured market sentiment signals (requires `ADANOS_API_KEY`)
 
 Then, click Submit！You'll get a response like this
 
 ![demo_response](figs/response.png)
 
-This is just a demo showing what this model is capable of. Results inferred from randomly chosen news can be strongly biased.
+This is just a demo showing what this model is capable of. Results inferred from randomly chosen news can be strongly biased. The optional Adanos market sentiment overlay helps reduce this by adding structured cross-source signals for recent windows.
 For more detailed and customized usage, scroll down and continue your reading.
 
 ## Deploy FinGPT-Forecaster
@@ -74,6 +75,36 @@ answer = re.sub(r'.*\[/INST\]\s*', '', output, flags=re.DOTALL) # don't forget t
 
 ## Data Preparation
 Company profile & Market news & Basic financials & Stock prices are retrieved using **yfinance & finnhub**.
+Structured market sentiment is available as an optional prompt enhancer using **Adanos**.
+
+## Optional Adanos Market Sentiment
+
+FinGPT-Forecaster can optionally enrich recent-window prompts with structured market sentiment from Reddit, X, Finance News, and Polymarket.
+
+Set the following environment variable before running the Gradio app or the online inference helper:
+
+```bash
+export ADANOS_API_KEY=your_api_key
+```
+
+What gets added to the prompt:
+
+- average sentiment score across available sources
+- source coverage
+- source alignment
+- per-source sentiment and activity counts
+
+Notes:
+
+- the integration is strictly optional; without `ADANOS_API_KEY` the Forecaster behaves exactly as before
+- it is intended for live/recent-window inference, not long-range historical backfills
+- recent-window availability depends on the public Adanos historical window for the selected account tier
+
+For offline data preparation, the same enrichment can be enabled in the dataset pipeline:
+
+```bash
+python data_pipeline.py --index_name dow --with_market_sentiment
+```
 
 Prompts used are organized as below:
 

--- a/fingpt/FinGPT_Forecaster/app.py
+++ b/fingpt/FinGPT_Forecaster/app.py
@@ -13,6 +13,7 @@ from peft import PeftModel
 from collections import defaultdict
 from datetime import date, datetime, timedelta
 from transformers import AutoTokenizer, AutoModelForCausalLM, TextStreamer
+from market_sentiment import enrich_recent_market_sentiment, format_market_sentiment_prompt
 
 # Increase HuggingFace Hub timeout to handle slow network connections or large file downloads
 os.environ.setdefault("HF_HUB_TIMEOUT", "120")
@@ -157,7 +158,11 @@ def get_prompt_by_row(symbol, row):
     else:
         basics = "[Basic Financials]:\n\nNo basic financial reported."
     
-    return head, news, basics
+    market_sentiment = ""
+    if "MarketSentiment" in row:
+        market_sentiment = format_market_sentiment_prompt(row["MarketSentiment"])
+
+    return head, news, market_sentiment, basics
 
 
 def sample_news(news, k=5):
@@ -197,8 +202,8 @@ def get_all_prompts_online(symbol, data, curday, with_basics=True):
     prev_rows = []
 
     for row_idx, row in data.iterrows():
-        head, news, _ = get_prompt_by_row(symbol, row)
-        prev_rows.append((head, news, None))
+        head, news, market_sentiment, _ = get_prompt_by_row(symbol, row)
+        prev_rows.append((head, news, market_sentiment, None))
         
     prompt = ""
     for i in range(-len(prev_rows), 0):
@@ -211,6 +216,8 @@ def get_all_prompts_online(symbol, data, curday, with_basics=True):
             prompt += "\n".join(sampled_news)
         else:
             prompt += "No relative news reported."
+        if prev_rows[i][2]:
+            prompt += "\n\n" + prev_rows[i][2]
         
     period = "{} to {}".format(curday, n_weeks_before(curday, -1))
     
@@ -228,7 +235,7 @@ def get_all_prompts_online(symbol, data, curday, with_basics=True):
     return info, prompt
 
 
-def construct_prompt(ticker, curday, n_weeks, use_basics):
+def construct_prompt(ticker, curday, n_weeks, use_basics, use_market_sentiment):
 
     try:
         steps = [n_weeks_before(curday, n) for n in range(n_weeks + 1)][::-1]
@@ -238,6 +245,8 @@ def construct_prompt(ticker, curday, n_weeks, use_basics):
     data = get_stock_data(ticker, steps)
     data = get_news(ticker, data)
     data['Basics'] = [json.dumps({})] * len(data)
+    if use_market_sentiment:
+        data = enrich_recent_market_sentiment(data, ticker, today=curday)
     # print(data)
     
     info, prompt = get_all_prompts_online(ticker, data, curday, use_basics)
@@ -248,11 +257,11 @@ def construct_prompt(ticker, curday, n_weeks, use_basics):
     return info, prompt
 
 
-def predict(ticker, date, n_weeks, use_basics):
+def predict(ticker, date, n_weeks, use_basics, use_market_sentiment):
 
     print_gpu_utilization()
 
-    info, prompt = construct_prompt(ticker, date, n_weeks, use_basics)
+    info, prompt = construct_prompt(ticker, date, n_weeks, use_basics, use_market_sentiment)
       
     inputs = tokenizer(
         prompt, return_tensors='pt', padding=False
@@ -299,6 +308,11 @@ demo = gr.Interface(
             label="Use Latest Basic Financials",
             value=False,
             info="If checked, the latest quarterly reported basic financials of the company is taken into account."
+        ),
+        gr.Checkbox(
+            label="Use Structured Market Sentiment",
+            value=False,
+            info="If checked, recent cross-source market sentiment is added when ADANOS_API_KEY is configured."
         )
     ],
     outputs=[
@@ -313,6 +327,7 @@ demo = gr.Interface(
     description="""FinGPT-Forecaster takes random market news and optional basic financials related to the specified company from the past few weeks as input and responds with the company's **positive developments** and **potential concerns**. Then it gives out a **prediction** of stock price movement for the coming week and its **analysis** summary.
 This model is finetuned on Llama2-7b-chat-hf with LoRA on the past year's DOW30 market data. Inference in this demo uses fp16 and **welcomes any ticker symbol**.
 Company profile & Market news & Basic financials & Stock prices are retrieved using **yfinance & finnhub**.
+Optional structured market sentiment can be added with **Adanos** when `ADANOS_API_KEY` is configured.
 This is just a demo showing what this model is capable of. Results inferred from randomly chosen news can be strongly biased.
 For more detailed and customized implementation, refer to our FinGPT project: <https://github.com/AI4Finance-Foundation/FinGPT>
 **Disclaimer: Nothing herein is financial advice, and NOT a recommendation to trade real money. Please use common sense and always first consult a professional before trading or investing.**

--- a/fingpt/FinGPT_Forecaster/data.py
+++ b/fingpt/FinGPT_Forecaster/data.py
@@ -15,6 +15,7 @@ from datasets import Dataset
 from openai import OpenAI
 
 from indices import *
+from market_sentiment import dataset_csv_path, enrich_recent_market_sentiment
 from prompt import get_all_prompts
 
 finnhub_client = finnhub.Client(api_key=os.environ.get("FINNHUB_KEY"))
@@ -115,17 +116,39 @@ def get_basics(symbol, data, start_date, always=False):
     return data
     
 
-def prepare_data_for_symbol(symbol, data_dir, start_date, end_date, with_basics=True):
+def prepare_data_for_symbol(
+    symbol,
+    data_dir,
+    start_date,
+    end_date,
+    with_basics=True,
+    with_market_sentiment=False,
+):
     
     data = get_returns(symbol, start_date, end_date)
     data = get_news(symbol, data)
+    if with_market_sentiment:
+        data = enrich_recent_market_sentiment(
+            data,
+            symbol,
+            today=end_date,
+        )
     
     if with_basics:
         data = get_basics(symbol, data, start_date)
-        data.to_csv(f"{data_dir}/{symbol}_{start_date}_{end_date}.csv")
     else:
         data['Basics'] = [json.dumps({})] * len(data)
-        data.to_csv(f"{data_dir}/{symbol}_{start_date}_{end_date}_nobasics.csv")
+
+    data.to_csv(
+        dataset_csv_path(
+            symbol,
+            data_dir,
+            start_date,
+            end_date,
+            with_basics=with_basics,
+            with_market_sentiment=with_market_sentiment,
+        )
+    )
     
     return data
 
@@ -149,12 +172,27 @@ def initialize_csv(filename):
         writer.writerow(["prompt", "answer"])
 
 
-def query_gpt4(symbol_list, data_dir, start_date, end_date, min_past_weeks=1, max_past_weeks=3, with_basics=True):
+def query_gpt4(
+    symbol_list,
+    data_dir,
+    start_date,
+    end_date,
+    min_past_weeks=1,
+    max_past_weeks=3,
+    with_basics=True,
+    with_market_sentiment=False,
+):
 
     for symbol in tqdm(symbol_list):
         
-        csv_file = f'{data_dir}/{symbol}_{start_date}_{end_date}_gpt-4.csv' if with_basics else \
-                   f'{data_dir}/{symbol}_{start_date}_{end_date}_nobasics_gpt-4.csv'
+        csv_file = dataset_csv_path(
+            symbol,
+            data_dir,
+            start_date,
+            end_date,
+            with_basics=with_basics,
+            with_market_sentiment=with_market_sentiment,
+        ).replace(".csv", "_gpt-4.csv")
         
         if not os.path.exists(csv_file):
             initialize_csv(csv_file)
@@ -163,7 +201,16 @@ def query_gpt4(symbol_list, data_dir, start_date, end_date, min_past_weeks=1, ma
             df = pd.read_csv(csv_file)
             pre_done = len(df)
 
-        prompts = get_all_prompts(symbol, data_dir, start_date, end_date, min_past_weeks, max_past_weeks, with_basics)
+        prompts = get_all_prompts(
+            symbol,
+            data_dir,
+            start_date,
+            end_date,
+            min_past_weeks,
+            max_past_weeks,
+            with_basics,
+            with_market_sentiment,
+        )
         system_prompt = SYSTEM_PROMPTS["crypto"] if symbol in CRYPTO else SYSTEM_PROMPTS["company"]
         for i, prompt in enumerate(prompts):
             
@@ -207,10 +254,16 @@ SYSTEM_PROMPTS = {
     "Your answer format should be as follows:\n\n[Positive Developments]:\n1. ...\n\n[Potential Concerns]:\n1. ...\n\n[Prediction & Analysis]:\n...\n",
 }
 
-def gpt4_to_llama(symbol, data_dir, start_date, end_date, with_basics=True):
+def gpt4_to_llama(symbol, data_dir, start_date, end_date, with_basics=True, with_market_sentiment=False):
 
-    csv_file = f'{data_dir}/{symbol}_{start_date}_{end_date}_gpt-4.csv' if with_basics else \
-                   f'{data_dir}/{symbol}_{start_date}_{end_date}_nobasics_gpt-4.csv'
+    csv_file = dataset_csv_path(
+        symbol,
+        data_dir,
+        start_date,
+        end_date,
+        with_basics=with_basics,
+        with_market_sentiment=with_market_sentiment,
+    ).replace(".csv", "_gpt-4.csv")
     
     df = pd.read_csv(csv_file)
     
@@ -261,14 +314,29 @@ def gpt4_to_llama(symbol, data_dir, start_date, end_date, with_basics=True):
     }
 
 
-def create_dataset(symbol_list, data_dir, start_date, end_date, train_ratio=0.8, with_basics=True):
+def create_dataset(
+    symbol_list,
+    data_dir,
+    start_date,
+    end_date,
+    train_ratio=0.8,
+    with_basics=True,
+    with_market_sentiment=False,
+):
 
     train_dataset_list = []
     test_dataset_list = []
 
     for symbol in symbol_list:
 
-        data_dict = gpt4_to_llama(symbol, data_dir, start_date, end_date,  with_basics)
+        data_dict = gpt4_to_llama(
+            symbol,
+            data_dir,
+            start_date,
+            end_date,
+            with_basics,
+            with_market_sentiment,
+        )
 #         print(data_dict['prompt'][-1])
 #         print(data_dict['answer'][-1])
         symbols = [symbol] * len(data_dict['label'])
@@ -289,6 +357,5 @@ def create_dataset(symbol_list, data_dir, start_date, end_date, train_ratio=0.8,
         'train': train_dataset,
         'test': test_dataset
     })
-    
+
     return dataset
-   

--- a/fingpt/FinGPT_Forecaster/data_infererence_fetch.py
+++ b/fingpt/FinGPT_Forecaster/data_infererence_fetch.py
@@ -6,6 +6,7 @@ from datetime import date, datetime, timedelta
 from collections import defaultdict
 
 from data import get_news
+from market_sentiment import enrich_recent_market_sentiment
 from prompt import get_company_prompt, get_prompt_by_row, sample_news
 
 finnhub_client = finnhub.Client(api_key=os.environ.get("FINNHUB_KEY"))
@@ -71,12 +72,14 @@ def get_current_basics(symbol, curday):
     return basic
 
 
-def fetch_all_data(symbol, curday, n_weeks=3):
+def fetch_all_data(symbol, curday, n_weeks=3, with_market_sentiment=False):
 
     steps = [n_weeks_before(curday, i) for i in range(n_weeks+1)][::-1]
 
     data = get_stock_data(symbol, steps)
     data = get_news(symbol, data)
+    if with_market_sentiment:
+        data = enrich_recent_market_sentiment(data, symbol, today=curday)
 
     return data
     
@@ -88,8 +91,8 @@ def get_all_prompts_online(symbol, data, curday, with_basics=True):
     prev_rows = []
 
     for row_idx, row in data.iterrows():
-        head, news, _ = get_prompt_by_row(symbol, row)
-        prev_rows.append((head, news, None))
+        head, news, market_sentiment, _ = get_prompt_by_row(symbol, row)
+        prev_rows.append((head, news, market_sentiment, None))
         
     prompt = ""
     for i in range(-len(prev_rows), 0):
@@ -102,6 +105,8 @@ def get_all_prompts_online(symbol, data, curday, with_basics=True):
             prompt += "\n".join(sampled_news)
         else:
             prompt += "No relative news reported."
+        if prev_rows[i][2]:
+            prompt += "\n\n" + prev_rows[i][2]
         
     period = "{} to {}".format(curday, n_weeks_before(curday, -1))
     

--- a/fingpt/FinGPT_Forecaster/data_pipeline.py
+++ b/fingpt/FinGPT_Forecaster/data_pipeline.py
@@ -17,6 +17,7 @@ def main(args):
     min_past_weeks = args['min_past_weeks']
     max_past_weeks = args['max_past_weeks']
     train_ratio = args['train_ratio']
+    with_market_sentiment = args['with_market_sentiment']
 
     with_basics = True
     if index_name == "dow":
@@ -39,15 +40,39 @@ def main(args):
     print("Acquiring data")
     for symbol in tqdm(index):
         print(f"Processing {symbol}")
-        prepare_data_for_symbol(symbol, data_dir, start_date, end_date, with_basics=with_basics)
+        prepare_data_for_symbol(
+            symbol,
+            data_dir,
+            start_date,
+            end_date,
+            with_basics=with_basics,
+            with_market_sentiment=with_market_sentiment,
+        )
 
     # Generate prompt and query GPT-4
     print("Generating prompts and querying GPT-4")
-    query_gpt4(index, data_dir, start_date, end_date, min_past_weeks, max_past_weeks, with_basics=with_basics)
+    query_gpt4(
+        index,
+        data_dir,
+        start_date,
+        end_date,
+        min_past_weeks,
+        max_past_weeks,
+        with_basics=with_basics,
+        with_market_sentiment=with_market_sentiment,
+    )
 
     # Transform into training format
     print("Transforming into training format")
-    dataset = create_dataset(index, data_dir, start_date, end_date, train_ratio, with_basics=with_basics)
+    dataset = create_dataset(
+        index,
+        data_dir,
+        start_date,
+        end_date,
+        train_ratio,
+        with_basics=with_basics,
+        with_market_sentiment=with_market_sentiment,
+    )
 
     # Save dataset
     dataset.save_to_disk(
@@ -64,6 +89,11 @@ if __name__ == "__main__":
     ap.add_argument("--min_past_weeks", default=1, help="min past weeks")
     ap.add_argument("--max_past_weeks", default=4, help="max past weeks")
     ap.add_argument("--train_ratio", default=0.6, help="train ratio")
+    ap.add_argument(
+        "--with_market_sentiment",
+        action="store_true",
+        help="optionally enrich prompts with Adanos market sentiment when ADANOS_API_KEY is set",
+    )
     args = vars(ap.parse_args())
 
     main(args)

--- a/fingpt/FinGPT_Forecaster/market_sentiment.py
+++ b/fingpt/FinGPT_Forecaster/market_sentiment.py
@@ -1,0 +1,307 @@
+import json
+import os
+from datetime import date, datetime, timedelta
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+import pandas as pd
+
+SUPPORTED_SOURCES = ("reddit", "x", "news", "polymarket")
+DEFAULT_BASE_URL = "https://api.adanos.org"
+MAX_LOOKBACK_DAYS = 90
+
+
+def dataset_csv_path(
+    symbol,
+    data_dir,
+    start_date,
+    end_date,
+    with_basics=True,
+    with_market_sentiment=False,
+):
+    suffix = ""
+    if not with_basics:
+        suffix += "_nobasics"
+    if with_market_sentiment:
+        suffix += "_sentiment"
+    return f"{data_dir}/{symbol}_{start_date}_{end_date}{suffix}.csv"
+
+
+def get_api_key(api_key=None):
+    return (api_key or os.environ.get("ADANOS_API_KEY", "")).strip()
+
+
+def enabled(api_key=None):
+    return bool(get_api_key(api_key))
+
+
+def _parse_date(value):
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if hasattr(value, "to_pydatetime"):
+        return value.to_pydatetime().date()
+    return datetime.strptime(str(value)[:10], "%Y-%m-%d").date()
+
+
+def _default_fetcher(url, headers, timeout=10):
+    request = Request(url, headers=headers)
+    with urlopen(request, timeout=timeout) as response:  # nosec: B310 - optional public API client
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _normalize_payload(payload):
+    if isinstance(payload, dict) and isinstance(payload.get("data"), dict):
+        return payload["data"]
+    return payload if isinstance(payload, dict) else {}
+
+
+def _safe_float(value):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_int(value):
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _extract_daily_trend(payload):
+    normalized = _normalize_payload(payload)
+    if not normalized.get("found", True):
+        return []
+
+    daily_trend = normalized.get("daily_trend") or []
+    if not isinstance(daily_trend, list):
+        return []
+
+    results = []
+    for item in daily_trend:
+        if not isinstance(item, dict) or "date" not in item:
+            continue
+
+        sentiment_score = _safe_float(
+            item.get("sentiment_score", item.get("sentiment"))
+        )
+        if sentiment_score is None:
+            continue
+
+        results.append(
+            {
+                "date": str(item["date"])[:10],
+                "mentions": _safe_int(item.get("mentions")),
+                "sentiment_score": sentiment_score,
+            }
+        )
+
+    return results
+
+
+def _fetch_source_daily_trend(
+    symbol,
+    source,
+    days,
+    api_key,
+    base_url=DEFAULT_BASE_URL,
+    fetcher=None,
+):
+    if fetcher is None:
+        fetcher = _default_fetcher
+
+    params = urlencode({"days": days})
+    url = "{}/{}/stocks/v1/stock/{}?{}".format(
+        base_url.rstrip("/"),
+        source,
+        symbol.upper(),
+        params,
+    )
+    headers = {"X-API-Key": api_key, "Accept": "application/json"}
+
+    try:
+        payload = fetcher(url, headers)
+    except (HTTPError, URLError, TimeoutError, ValueError):
+        return []
+
+    return _extract_daily_trend(payload)
+
+
+def _aggregate_period_signal(source, daily_trend, start_date, end_date):
+    window = [
+        item
+        for item in daily_trend
+        if start_date <= _parse_date(item["date"]) <= end_date
+    ]
+    total_mentions = sum(item["mentions"] for item in window)
+
+    if not window or total_mentions <= 0:
+        return {
+            "source": source,
+            "available": False,
+            "average_sentiment_score": None,
+            "total_mentions": 0,
+        }
+
+    average_sentiment = sum(item["sentiment_score"] for item in window) / len(window)
+    return {
+        "source": source,
+        "available": True,
+        "average_sentiment_score": round(average_sentiment, 3),
+        "total_mentions": total_mentions,
+    }
+
+
+def _sentiment_label(value):
+    if value is None:
+        return "unavailable"
+    if value >= 0.2:
+        return "bullish"
+    if value <= -0.2:
+        return "bearish"
+    return "mixed"
+
+
+def _source_alignment(scores):
+    if not scores:
+        return "unavailable"
+    if len(scores) == 1:
+        return "single-source"
+
+    spread = max(scores) - min(scores)
+    if spread <= 0.15:
+        return "aligned"
+    if spread <= 0.4:
+        return "mixed"
+    return "divergent"
+
+
+def summarize_market_sentiment(signals):
+    available = [signal for signal in signals if signal["available"]]
+    if not available:
+        return {}
+
+    scores = [signal["average_sentiment_score"] for signal in available]
+    total_mentions = sum(signal["total_mentions"] for signal in available)
+    average_sentiment = sum(scores) / len(scores)
+
+    return {
+        "available": True,
+        "average_sentiment_score": round(average_sentiment, 3),
+        "average_sentiment_label": _sentiment_label(average_sentiment),
+        "total_mentions": total_mentions,
+        "coverage": len(available),
+        "source_alignment": _source_alignment(scores),
+        "sources": {signal["source"]: signal for signal in available},
+    }
+
+
+def enrich_recent_market_sentiment(
+    data,
+    symbol,
+    api_key=None,
+    base_url=DEFAULT_BASE_URL,
+    fetcher=None,
+    today=None,
+    sources=SUPPORTED_SOURCES,
+):
+    enriched = data.copy()
+    enriched["MarketSentiment"] = [json.dumps({})] * len(enriched)
+
+    api_key = get_api_key(api_key)
+    if not api_key or enriched.empty:
+        return enriched
+
+    today = _parse_date(today or date.today())
+    cutoff = today - timedelta(days=MAX_LOOKBACK_DAYS - 1)
+
+    candidate_starts = []
+    for _, row in enriched.iterrows():
+        start_date = _parse_date(row["Start Date"])
+        end_date = _parse_date(row["End Date"])
+        if end_date < cutoff or start_date > today:
+            continue
+        candidate_starts.append(max(start_date, cutoff))
+
+    if not candidate_starts:
+        return enriched
+
+    earliest_date = min(candidate_starts)
+    days = min(MAX_LOOKBACK_DAYS, max(1, (today - earliest_date).days + 1))
+
+    source_trends = {}
+    for source in sources:
+        source_trends[source] = _fetch_source_daily_trend(
+            symbol=symbol,
+            source=source,
+            days=days,
+            api_key=api_key,
+            base_url=base_url,
+            fetcher=fetcher,
+        )
+
+    market_sentiment = []
+    for _, row in enriched.iterrows():
+        start_date = _parse_date(row["Start Date"])
+        end_date = _parse_date(row["End Date"])
+
+        if end_date < cutoff or start_date > today:
+            market_sentiment.append(json.dumps({}))
+            continue
+
+        period_start = max(start_date, cutoff)
+        period_end = min(end_date, today)
+        signals = [
+            _aggregate_period_signal(source, source_trends.get(source, []), period_start, period_end)
+            for source in sources
+        ]
+        market_sentiment.append(json.dumps(summarize_market_sentiment(signals)))
+
+    enriched["MarketSentiment"] = market_sentiment
+    return enriched
+
+
+def format_market_sentiment_prompt(value):
+    if not value:
+        return ""
+
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return ""
+
+    if not isinstance(value, dict) or not value.get("available"):
+        return ""
+
+    average_sentiment = value.get("average_sentiment_score")
+    header = "[Market Sentiment Signals]:"
+    lines = [
+        header,
+        "",
+        "Average sentiment score: {:.3f} ({})".format(
+            average_sentiment,
+            value.get("average_sentiment_label", _sentiment_label(average_sentiment)),
+        ),
+        "Source coverage: {}/{}".format(value.get("coverage", 0), len(SUPPORTED_SOURCES)),
+        "Source alignment: {}".format(value.get("source_alignment", "unavailable")),
+        "Total sentiment activity: {}".format(value.get("total_mentions", 0)),
+    ]
+
+    for source in SUPPORTED_SOURCES:
+        source_signal = value.get("sources", {}).get(source)
+        if not source_signal:
+            continue
+        lines.append(
+            "- {}: sentiment {:.3f}, mentions {}".format(
+                source.capitalize(),
+                source_signal["average_sentiment_score"],
+                source_signal["total_mentions"],
+            )
+        )
+
+    return "\n".join(lines)

--- a/fingpt/FinGPT_Forecaster/prompt.py
+++ b/fingpt/FinGPT_Forecaster/prompt.py
@@ -7,6 +7,7 @@ import pandas as pd
 from openai import OpenAI
 
 from indices import *
+from market_sentiment import dataset_csv_path, format_market_sentiment_prompt
 
 finnhub_client = finnhub.Client(api_key=os.environ.get("FINNHUB_KEY"))
 
@@ -53,8 +54,12 @@ def get_prompt_by_row(symbol, row):
             symbol, basics['period']) + "\n".join(f"{k}: {v}" for k, v in basics.items() if k != 'period')
     else:
         basics = "[Basic Financials]:\n\nNo basic financial reported."
+
+    market_sentiment = format_market_sentiment_prompt(
+        row["MarketSentiment"] if "MarketSentiment" in row else None
+    )
     
-    return head, news, basics
+    return head, news, market_sentiment, basics
 
 
 def get_crypto_prompt_by_row(symbol, row):
@@ -70,7 +75,7 @@ def get_crypto_prompt_by_row(symbol, row):
         n['headline'], n['summary']) for n in news if n['date'][:8] <= end_date.replace('-', '') and \
         not n['summary'].startswith("Looking for stock market analysis and research with proves results?")]
 
-    return head, news, None
+    return head, news, "", "[Basic Financials]:\n\nNo basic financial reported."
 
 
 def sample_news(news, k=5):
@@ -102,13 +107,28 @@ PROMPT_END = {
         "Then let's assume your prediction for next week ({start_date} to {end_date}) is {prediction}. Provide a summary analysis to support your prediction. The prediction result need to be inferred from your analysis at the end, and thus not appearing as a foundational factor of your analysis."
 }
 
-def get_all_prompts(symbol, data_dir, start_date, end_date, min_past_weeks=1, max_past_weeks=3, with_basics=True):
+def get_all_prompts(
+    symbol,
+    data_dir,
+    start_date,
+    end_date,
+    min_past_weeks=1,
+    max_past_weeks=3,
+    with_basics=True,
+    with_market_sentiment=False,
+):
 
     
-    if with_basics:
-        df = pd.read_csv(f'{data_dir}/{symbol}_{start_date}_{end_date}.csv')
-    else:
-        df = pd.read_csv(f'{data_dir}/{symbol}_{start_date}_{end_date}_nobasics.csv')
+    df = pd.read_csv(
+        dataset_csv_path(
+            symbol,
+            data_dir,
+            start_date,
+            end_date,
+            with_basics=with_basics,
+            with_market_sentiment=with_market_sentiment,
+        )
+    )
     
     if symbol in CRYPTO:
         info_prompt = get_crypto_prompt(symbol)
@@ -135,13 +155,15 @@ def get_all_prompts(symbol, data_dir, start_date, end_date, min_past_weeks=1, ma
                     prompt += "\n".join(sampled_news)
                 else:
                     prompt += "No relative news reported."
+                if prev_rows[i][2]:
+                    prompt += "\n\n" + prev_rows[i][2]
 
         if symbol in CRYPTO:
-            head, news, basics = get_crypto_prompt_by_row(symbol, row)
+            head, news, market_sentiment, basics = get_crypto_prompt_by_row(symbol, row)
         else:
-            head, news, basics = get_prompt_by_row(symbol, row)
+            head, news, market_sentiment, basics = get_prompt_by_row(symbol, row)
 
-        prev_rows.append((head, news, basics))
+        prev_rows.append((head, news, market_sentiment, basics))
         if len(prev_rows) > max_past_weeks:
             prev_rows.pop(0)  
 
@@ -150,7 +172,10 @@ def get_all_prompts(symbol, data_dir, start_date, end_date, min_past_weeks=1, ma
 
         prediction = map_bin_label(row['Bin Label'])
         
-        prompt = info_prompt + '\n' + prompt + '\n' + basics
+        prompt = info_prompt + '\n' + prompt
+        if market_sentiment:
+            prompt += '\n' + market_sentiment
+        prompt += '\n' + basics
 
         prompt += PROMPT_END['crypto' if symbol in CRYPTO else 'company'].format(
             start_date=row['Start Date'],

--- a/tests/test_forecaster_market_sentiment.py
+++ b/tests/test_forecaster_market_sentiment.py
@@ -1,0 +1,160 @@
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+
+
+FORECASTER_DIR = Path(__file__).resolve().parents[1] / "fingpt" / "FinGPT_Forecaster"
+if str(FORECASTER_DIR) not in sys.path:
+    sys.path.insert(0, str(FORECASTER_DIR))
+
+from market_sentiment import (
+    dataset_csv_path,
+    enrich_recent_market_sentiment,
+    format_market_sentiment_prompt,
+)
+
+
+def _build_payload(entries):
+    return {"ticker": "AAPL", "found": True, "daily_trend": entries}
+
+
+def test_enrich_recent_market_sentiment_aggregates_recent_windows():
+    data = pd.DataFrame(
+        {
+            "Start Date": [pd.Timestamp("2026-04-01"), pd.Timestamp("2026-04-08")],
+            "End Date": [pd.Timestamp("2026-04-07"), pd.Timestamp("2026-04-10")],
+        }
+    )
+
+    source_payloads = {
+        "reddit": _build_payload(
+            [
+                {"date": "2026-04-03", "mentions": 12, "sentiment_score": 0.40},
+                {"date": "2026-04-05", "mentions": 18, "sentiment_score": 0.20},
+                {"date": "2026-04-09", "mentions": 8, "sentiment_score": 0.10},
+            ]
+        ),
+        "x": _build_payload(
+            [
+                {"date": "2026-04-02", "mentions": 10, "sentiment_score": 0.10},
+                {"date": "2026-04-06", "mentions": 5, "sentiment_score": 0.00},
+                {"date": "2026-04-10", "mentions": 6, "sentiment_score": -0.10},
+            ]
+        ),
+        "news": _build_payload(
+            [
+                {"date": "2026-04-04", "mentions": 7, "sentiment_score": 0.05},
+                {"date": "2026-04-08", "mentions": 9, "sentiment_score": 0.15},
+            ]
+        ),
+        "polymarket": _build_payload([]),
+    }
+
+    def fetcher(url, headers):
+        assert headers["X-API-Key"] == "demo-key"
+        for source, payload in source_payloads.items():
+            if "/{}/".format(source) in url:
+                return payload
+        raise AssertionError("unexpected url {}".format(url))
+
+    enriched = enrich_recent_market_sentiment(
+        data,
+        "AAPL",
+        api_key="demo-key",
+        fetcher=fetcher,
+        today=date(2026, 4, 10),
+    )
+
+    first_window = json.loads(enriched.loc[0, "MarketSentiment"])
+    second_window = json.loads(enriched.loc[1, "MarketSentiment"])
+
+    assert first_window["available"] is True
+    assert first_window["coverage"] == 3
+    assert first_window["total_mentions"] == 52
+    assert first_window["average_sentiment_label"] == "mixed"
+    assert first_window["source_alignment"] == "mixed"
+    assert first_window["sources"]["reddit"]["total_mentions"] == 30
+
+    assert second_window["available"] is True
+    assert second_window["coverage"] == 3
+    assert second_window["total_mentions"] == 23
+    assert second_window["sources"]["x"]["average_sentiment_score"] == -0.1
+
+
+def test_enrich_recent_market_sentiment_is_noop_without_key():
+    data = pd.DataFrame(
+        {
+            "Start Date": [pd.Timestamp("2026-04-01")],
+            "End Date": [pd.Timestamp("2026-04-07")],
+        }
+    )
+
+    enriched = enrich_recent_market_sentiment(data, "AAPL", api_key="", today=date(2026, 4, 10))
+
+    assert json.loads(enriched.loc[0, "MarketSentiment"]) == {}
+
+
+def test_enrich_recent_market_sentiment_skips_windows_outside_supported_history():
+    data = pd.DataFrame(
+        {
+            "Start Date": [pd.Timestamp("2025-10-01")],
+            "End Date": [pd.Timestamp("2025-10-07")],
+        }
+    )
+
+    enriched = enrich_recent_market_sentiment(data, "AAPL", api_key="demo-key", today=date(2026, 4, 10))
+
+    assert json.loads(enriched.loc[0, "MarketSentiment"]) == {}
+
+
+def test_format_market_sentiment_prompt_renders_structured_block():
+    payload = {
+        "available": True,
+        "average_sentiment_score": 0.183,
+        "average_sentiment_label": "mixed",
+        "coverage": 3,
+        "source_alignment": "aligned",
+        "total_mentions": 41,
+        "sources": {
+            "reddit": {"average_sentiment_score": 0.25, "total_mentions": 20},
+            "x": {"average_sentiment_score": 0.15, "total_mentions": 11},
+            "news": {"average_sentiment_score": 0.15, "total_mentions": 10},
+        },
+    }
+
+    block = format_market_sentiment_prompt(payload)
+
+    assert "[Market Sentiment Signals]:" in block
+    assert "Average sentiment score: 0.183 (mixed)" in block
+    assert "Source coverage: 3/4" in block
+    assert "- Reddit: sentiment 0.250, mentions 20" in block
+
+
+def test_format_market_sentiment_prompt_is_empty_without_available_data():
+    assert format_market_sentiment_prompt({}) == ""
+    assert format_market_sentiment_prompt('{"available": false}') == ""
+
+
+def test_dataset_csv_path_tracks_optional_sentiment_suffix():
+    with_basics = dataset_csv_path("AAPL", "/tmp/data", "2026-01-01", "2026-02-01")
+    no_basics = dataset_csv_path(
+        "AAPL",
+        "/tmp/data",
+        "2026-01-01",
+        "2026-02-01",
+        with_basics=False,
+    )
+    with_sentiment = dataset_csv_path(
+        "AAPL",
+        "/tmp/data",
+        "2026-01-01",
+        "2026-02-01",
+        with_market_sentiment=True,
+    )
+
+    assert with_basics.endswith("/AAPL_2026-01-01_2026-02-01.csv")
+    assert no_basics.endswith("/AAPL_2026-01-01_2026-02-01_nobasics.csv")
+    assert with_sentiment.endswith("/AAPL_2026-01-01_2026-02-01_sentiment.csv")


### PR DESCRIPTION
## Summary

This PR adds an optional structured market sentiment enhancer to `FinGPT_Forecaster`.

It introduces a small Adanos-backed helper that can enrich recent-window forecasting prompts with cross-source market sentiment signals from Reddit, X, Finance News, and Polymarket.

## What changes

- adds `market_sentiment.py` to fetch and summarize recent market sentiment signals
- enriches Forecaster prompts with an optional `[Market Sentiment Signals]` block
- wires the same optional path into both:
  - the Gradio demo / online inference flow
  - the offline `data_pipeline.py` dataset preparation flow
- keeps the integration strictly optional and fail-open when `ADANOS_API_KEY` is not configured
- adds focused tests and README usage notes

## Why this fits FinGPT-Forecaster

`FinGPT_Forecaster` already builds prompts from recent price movement, company news, and optional basic financials. This patch keeps that architecture intact and only adds an additional structured signal layer for recent windows.

That is a better fit here than introducing a new primary market-data provider or changing the broader FinGPT stack.

## Optional behavior

- no request is made unless `ADANOS_API_KEY` is set
- without the key, Forecaster behavior is unchanged
- the feature is intended for recent-window inference / prompt enrichment, not historical long-range backfills

## Validation

- `python3 -m pytest tests/ -q`
- `python3 -m py_compile fingpt/FinGPT_Forecaster/market_sentiment.py fingpt/FinGPT_Forecaster/data.py fingpt/FinGPT_Forecaster/prompt.py fingpt/FinGPT_Forecaster/data_infererence_fetch.py fingpt/FinGPT_Forecaster/data_pipeline.py fingpt/FinGPT_Forecaster/app.py tests/test_forecaster_market_sentiment.py`
- `git diff --check`
