### PR TITLE
fix: replace max_length with max_new_tokens in FinGPT Forecaster demo

### DIFF
--- a/fingpt/FinGPT_Forecaster/demo.ipynb
+++ b/fingpt/FinGPT_Forecaster/demo.ipynb
@@ -88,28 +88,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "fe9b99e6-f4be-4dcc-820a-ccb95d819904",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "def test_demo(model, tokenizer, prompt):\n",
-    "\n",
-    "    inputs = tokenizer(\n",
-    "        prompt, return_tensors='pt',\n",
-    "        padding=False, max_length=4096\n",
-    "    )\n",
-    "    inputs = {key: value.to(model.device) for key, value in inputs.items()}\n",
-    "        \n",
-    "    res = model.generate(\n",
-    "        **inputs, max_length=4096, do_sample=True,\n",
-    "        eos_token_id=tokenizer.eos_token_id,\n",
-    "        use_cache=True\n",
-    "    )\n",
-    "    output = tokenizer.decode(res[0], skip_special_tokens=True)\n",
-    "    return output    \n",
-    "    # return res"
-   ]
+   "source": "def test_demo(model, tokenizer, prompt):\n\n    inputs = tokenizer(\n        prompt, return_tensors='pt',\n        padding=False, max_length=4096,\n        truncation=True\n    )\n    inputs = {key: value.to(model.device) for key, value in inputs.items()}\n        \n    res = model.generate(\n        **inputs, max_new_tokens=512, do_sample=True,\n        eos_token_id=tokenizer.eos_token_id,\n        use_cache=True\n    )\n    output = tokenizer.decode(res[0], skip_special_tokens=True)\n    return output    \n    # return res"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Fixes #202

## Problem

The `test_demo()` function in `fingpt/FinGPT_Forecaster/demo.ipynb` uses `max_length=4096` in `model.generate()`. This parameter specifies the **total** sequence length (input tokens + output tokens combined), not just new tokens.

Financial analysis prompts in this demo typically contain 2000–3000+ tokens of market news and data. With `max_length=4096`, the model only has ~1000 tokens or fewer to generate a response. For LoRA-finetuned models that are trained to produce detailed structured outputs, this constraint causes the model to return empty or severely truncated predictions — the issue reported in #202.

The base model may appear to work because it tends to produce shorter outputs that fit within the remaining budget, while the fine-tuned model (which generates longer, more structured forecasts) hits the limit immediately.

## Solution

- Replace `max_length=4096` with `max_new_tokens=512` in `model.generate()` so the model always has 512 tokens of generation budget regardless of prompt length.
- Add `truncation=True` to the tokenizer call to safely handle edge cases where the prompt itself exceeds 4096 tokens.

## Testing

The fix aligns with the standard HuggingFace recommendation for generation tasks: use `max_new_tokens` to control output length independently from input length.