### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ For the Finogrid platform (finogrid/), FinGPT supports multiple cloud LLM provid
 | Provider | Model | Context Length | Use Case |
 |----------|-------|---------------|----------|
 | OpenAI | GPT-3.5-turbo | 16K | Default fallback for sentiment & agents |
-| [MiniMax](https://platform.minimaxi.com/) | MiniMax-M2.7 | 204K | Latest flagship model with enhanced reasoning and coding |
+| [MiniMax](https://platform.minimaxi.com/) | MiniMax-M3 | 512K | Latest flagship model with 128K max output and image input support |
 | FinGPT (local) | Llama-2-13B LoRA | 4K | Full local inference (requires GPU) |
 
 ## Open-Source Base Model used in the LLMs layer of FinGPT

--- a/finogrid/fingpt_integration/__init__.py
+++ b/finogrid/fingpt_integration/__init__.py
@@ -18,7 +18,7 @@ instead of loading the full 13B model locally. Same quality for early stage.
 
 LLM provider selection (for sentiment analysis and agent LLM client):
   FINGPT_LLM_PROVIDER=openai   → OpenAI GPT-3.5-turbo (default)
-  FINGPT_LLM_PROVIDER=minimax  → MiniMax MiniMax-M2.7 (enhanced reasoning and coding)
+  FINGPT_LLM_PROVIDER=minimax  → MiniMax MiniMax-M3 (512K context, 128K max output, image input)
   FINGPT_LLM_PROVIDER=fingpt   → Local FinGPT model (requires GPU)
 """
 import os

--- a/finogrid/fingpt_integration/minimax_llm_client.py
+++ b/finogrid/fingpt_integration/minimax_llm_client.py
@@ -35,7 +35,7 @@ class MiniMaxLLMClient:
 
     def __init__(
         self,
-        model: str = "MiniMax-M2.7",
+        model: str = "MiniMax-M3",
         temperature: float = 0.7,
         max_tokens: int = 1024,
     ):

--- a/finogrid/fingpt_integration/sentiment/minimax_provider.py
+++ b/finogrid/fingpt_integration/sentiment/minimax_provider.py
@@ -1,7 +1,8 @@
 """
 MiniMax provider for FinGPT sentiment — cost-effective alternative to OpenAI.
 
-Uses MiniMax's OpenAI-compatible API with MiniMax-M2.7 (enhanced reasoning and coding).
+Uses MiniMax's OpenAI-compatible API with MiniMax-M3 (latest flagship with
+512K context, 128K max output, image input support).
 Same interface as OpenAISentimentFallback — drop-in replacement.
 
 MiniMax API docs: https://platform.minimaxi.com/
@@ -35,7 +36,7 @@ class MiniMaxSentimentProvider:
     with a custom base_url.
     """
 
-    def __init__(self, model: str = "MiniMax-M2.7"):
+    def __init__(self, model: str = "MiniMax-M3"):
         self.model = model
         api_key = os.getenv("MINIMAX_API_KEY")
         if not api_key:

--- a/finogrid/fingpt_integration/sentiment/openai_fallback.py
+++ b/finogrid/fingpt_integration/sentiment/openai_fallback.py
@@ -78,7 +78,7 @@ def get_sentiment_analyzer():
       2. FINGPT_USE_OPENAI_FALLBACK env var (legacy): "true" → OpenAI, "false" → FinGPT model
 
     Examples:
-      FINGPT_LLM_PROVIDER=minimax  →  MiniMax MiniMax-M2.7
+      FINGPT_LLM_PROVIDER=minimax  →  MiniMax MiniMax-M3
       FINGPT_LLM_PROVIDER=openai   →  OpenAI GPT-3.5-turbo (default)
       FINGPT_LLM_PROVIDER=fingpt   →  Local FinGPT Llama-2 model (requires GPU)
     """

--- a/finogrid/tests/unit/test_minimax_provider.py
+++ b/finogrid/tests/unit/test_minimax_provider.py
@@ -15,14 +15,14 @@ class TestMiniMaxSentimentProvider:
     def test_init_with_api_key(self):
         from finogrid.fingpt_integration.sentiment.minimax_provider import MiniMaxSentimentProvider
         provider = MiniMaxSentimentProvider()
-        assert provider.model == "MiniMax-M2.7"
+        assert provider.model == "MiniMax-M3"
         assert provider.client is not None
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"})
     def test_init_custom_model(self):
         from finogrid.fingpt_integration.sentiment.minimax_provider import MiniMaxSentimentProvider
-        provider = MiniMaxSentimentProvider(model="MiniMax-M2.7-highspeed")
-        assert provider.model == "MiniMax-M2.7-highspeed"
+        provider = MiniMaxSentimentProvider(model="MiniMax-M2.7")
+        assert provider.model == "MiniMax-M2.7"
 
     @patch.dict(os.environ, {}, clear=True)
     def test_init_missing_api_key(self):
@@ -179,7 +179,7 @@ class TestMiniMaxLLMClient:
     def test_init_defaults(self):
         from finogrid.fingpt_integration.minimax_llm_client import MiniMaxLLMClient
         client = MiniMaxLLMClient()
-        assert client.model == "MiniMax-M2.7"
+        assert client.model == "MiniMax-M3"
         assert client.temperature == 0.7
         assert client.max_tokens == 1024
 
@@ -187,11 +187,11 @@ class TestMiniMaxLLMClient:
     def test_init_custom_params(self):
         from finogrid.fingpt_integration.minimax_llm_client import MiniMaxLLMClient
         client = MiniMaxLLMClient(
-            model="MiniMax-M2.7-highspeed",
+            model="MiniMax-M2.7",
             temperature=0.5,
             max_tokens=2048,
         )
-        assert client.model == "MiniMax-M2.7-highspeed"
+        assert client.model == "MiniMax-M2.7"
         assert client.temperature == 0.5
         assert client.max_tokens == 2048
 


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to use the latest M3 flagship as the default for both the sentiment provider and the generic LLM client in `finogrid/fingpt_integration/`.

## Changes
- Set `MiniMax-M3` as the new default for `MiniMaxLLMClient` and `MiniMaxSentimentProvider`
- Retain `MiniMax-M2.7` as an available alternative (and `MiniMax-M2.7-highspeed` still works via the explicit `model=` parameter)
- Update root `README.md` cloud LLM provider table to reflect M3 capabilities (512K context, 128K max output, image input)
- Update docstrings in `__init__.py` and `openai_fallback.py`
- Update unit tests in `finogrid/tests/unit/test_minimax_provider.py` for the new default

## Why
`MiniMax-M3` is the new flagship model with 512K context window, 128K max output, and image input support — a clear capability upgrade over M2.7's 204K context. Keeping `MiniMax-M2.7` available preserves the ability to pin the previous model for users that need it.

## Testing
- All 24 unit tests in `finogrid/tests/unit/test_minimax_provider.py` pass
- API URL (`https://api.minimax.io/v1`), temperature clamping `(0.0, 1.0]`, and `MINIMAX_API_KEY` env var are unchanged