### PR TITLE
fix: make Forecaster runtime device-safe

### DIFF
--- a/fingpt/FinGPT_Forecaster/README.md
+++ b/fingpt/FinGPT_Forecaster/README.md
@@ -45,7 +45,7 @@ base_model = AutoModelForCausalLM.from_pretrained(
     'meta-llama/Llama-2-7b-chat-hf',
     trust_remote_code=True,
     device_map="auto",
-    torch_dtype=torch.float16,   # optional if you have enough VRAM
+    torch_dtype=torch.float16 if torch.cuda.is_available() else torch.float32,
 )
 tokenizer = AutoTokenizer.from_pretrained('meta-llama/Llama-2-7b-chat-hf')
 
@@ -72,6 +72,9 @@ res = model.generate(
 output = tokenizer.decode(res[0], skip_special_tokens=True)
 answer = re.sub(r'.*\[/INST\]\s*', '', output, flags=re.DOTALL) # don't forget to import re
 ```
+
+By default, the Gradio app uses `torch.float16` when CUDA is available and `torch.float32` on CPU-only machines.
+You can override this with `FINGPT_TORCH_DTYPE=float32`, `float16`, or `bfloat16`.
 
 ## Data Preparation
 Company profile & Market news & Basic financials & Stock prices are retrieved using **yfinance & finnhub**.

--- a/fingpt/FinGPT_Forecaster/app.py
+++ b/fingpt/FinGPT_Forecaster/app.py
@@ -8,12 +8,12 @@ import torch
 import gradio as gr
 import pandas as pd
 import yfinance as yf
-from pynvml import *
 from peft import PeftModel
 from collections import defaultdict
 from datetime import date, datetime, timedelta
 from transformers import AutoTokenizer, AutoModelForCausalLM, TextStreamer
 from market_sentiment import enrich_recent_market_sentiment, format_market_sentiment_prompt
+from runtime_utils import empty_cuda_cache, print_gpu_utilization as report_gpu_utilization, resolve_torch_dtype
 
 # Increase HuggingFace Hub timeout to handle slow network connections or large file downloads
 os.environ.setdefault("HF_HUB_TIMEOUT", "120")
@@ -26,7 +26,7 @@ base_model = AutoModelForCausalLM.from_pretrained(
     token=access_token,
     trust_remote_code=True, 
     device_map="auto",
-    torch_dtype=torch.float16,
+    torch_dtype=resolve_torch_dtype(torch),
     offload_folder="offload/"
 )
 model = PeftModel.from_pretrained(
@@ -51,11 +51,7 @@ SYSTEM_PROMPT = "You are a seasoned stock market analyst. Your task is to list t
 
 
 def print_gpu_utilization():
-    
-    nvmlInit()
-    handle = nvmlDeviceGetHandleByIndex(0)
-    info = nvmlDeviceGetMemoryInfo(handle)
-    print(f"GPU memory occupied: {info.used//1024**2} MB.")
+    return report_gpu_utilization(torch)
 
 
 def get_curday():
@@ -278,7 +274,7 @@ def predict(ticker, date, n_weeks, use_basics, use_market_sentiment):
     output = tokenizer.decode(res[0], skip_special_tokens=True)
     answer = re.sub(r'.*\[/INST\]\s*', '', output, flags=re.DOTALL)
 
-    torch.cuda.empty_cache()
+    empty_cuda_cache(torch)
     
     return info, answer
 
@@ -325,7 +321,7 @@ demo = gr.Interface(
     ],
     title="FinGPT-Forecaster",
     description="""FinGPT-Forecaster takes random market news and optional basic financials related to the specified company from the past few weeks as input and responds with the company's **positive developments** and **potential concerns**. Then it gives out a **prediction** of stock price movement for the coming week and its **analysis** summary.
-This model is finetuned on Llama2-7b-chat-hf with LoRA on the past year's DOW30 market data. Inference in this demo uses fp16 and **welcomes any ticker symbol**.
+This model is finetuned on Llama2-7b-chat-hf with LoRA on the past year's DOW30 market data. Inference uses fp16 on CUDA by default and fp32 on CPU, and **welcomes any ticker symbol**.
 Company profile & Market news & Basic financials & Stock prices are retrieved using **yfinance & finnhub**.
 Optional structured market sentiment can be added with **Adanos** when `ADANOS_API_KEY` is configured.
 This is just a demo showing what this model is capable of. Results inferred from randomly chosen news can be strongly biased.

--- a/fingpt/FinGPT_Forecaster/runtime_utils.py
+++ b/fingpt/FinGPT_Forecaster/runtime_utils.py
@@ -1,0 +1,65 @@
+import os
+
+
+def resolve_torch_dtype(torch_module, env=None):
+    """Resolve the inference dtype for the current runtime."""
+    env = os.environ if env is None else env
+    dtype_name = env.get("FINGPT_TORCH_DTYPE", "auto").strip().lower()
+    dtype_by_name = {
+        "float16": torch_module.float16,
+        "fp16": torch_module.float16,
+        "float32": torch_module.float32,
+        "fp32": torch_module.float32,
+    }
+    if hasattr(torch_module, "bfloat16"):
+        dtype_by_name["bfloat16"] = torch_module.bfloat16
+        dtype_by_name["bf16"] = torch_module.bfloat16
+
+    if dtype_name in dtype_by_name:
+        return dtype_by_name[dtype_name]
+    if dtype_name not in {"", "auto"}:
+        valid = ", ".join(sorted([*dtype_by_name, "auto"]))
+        raise ValueError(f"Invalid FINGPT_TORCH_DTYPE={dtype_name!r}; expected one of: {valid}")
+
+    return torch_module.float16 if torch_module.cuda.is_available() else torch_module.float32
+
+
+def print_gpu_utilization(torch_module, nvml_module=None):
+    """Print GPU memory usage when CUDA/NVML are available.
+
+    Returns True when a GPU memory report was printed and False when reporting
+    was skipped. Inference should not fail just because NVML is unavailable on a
+    Windows or CPU-only runtime.
+    """
+    if not torch_module.cuda.is_available():
+        print("CUDA is not available; skipping GPU memory report.")
+        return False
+
+    if nvml_module is None:
+        try:
+            import pynvml as nvml_module
+        except Exception as exc:
+            print(f"GPU memory report unavailable: {exc}")
+            return False
+
+    try:
+        nvml_module.nvmlInit()
+        handle = nvml_module.nvmlDeviceGetHandleByIndex(0)
+        info = nvml_module.nvmlDeviceGetMemoryInfo(handle)
+        print(f"GPU memory occupied: {info.used // 1024**2} MB.")
+        return True
+    except Exception as exc:
+        print(f"GPU memory report unavailable: {exc}")
+        return False
+    finally:
+        shutdown = getattr(nvml_module, "nvmlShutdown", None)
+        if callable(shutdown):
+            try:
+                shutdown()
+            except Exception:
+                pass
+
+
+def empty_cuda_cache(torch_module):
+    if torch_module.cuda.is_available():
+        torch_module.cuda.empty_cache()

--- a/fingpt/FinGPT_Forecaster/tests/test_runtime_utils.py
+++ b/fingpt/FinGPT_Forecaster/tests/test_runtime_utils.py
@@ -1,0 +1,112 @@
+import io
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from runtime_utils import empty_cuda_cache, print_gpu_utilization, resolve_torch_dtype
+
+
+class FakeCuda:
+    def __init__(self, available):
+        self.available = available
+        self.empty_cache_called = False
+
+    def is_available(self):
+        return self.available
+
+    def empty_cache(self):
+        self.empty_cache_called = True
+
+
+class FakeTorch:
+    float16 = "float16"
+    float32 = "float32"
+    bfloat16 = "bfloat16"
+
+    def __init__(self, cuda_available):
+        self.cuda = FakeCuda(cuda_available)
+
+
+class FakeMemoryInfo:
+    used = 512 * 1024**2
+
+
+class FakeNvml:
+    def __init__(self):
+        self.shutdown_called = False
+
+    def nvmlInit(self):
+        return None
+
+    def nvmlDeviceGetHandleByIndex(self, index):
+        return f"gpu-{index}"
+
+    def nvmlDeviceGetMemoryInfo(self, handle):
+        return FakeMemoryInfo()
+
+    def nvmlShutdown(self):
+        self.shutdown_called = True
+
+
+class RuntimeUtilsTest(unittest.TestCase):
+    def test_resolve_dtype_uses_float16_on_cuda(self):
+        self.assertEqual(resolve_torch_dtype(FakeTorch(cuda_available=True), env={}), "float16")
+
+    def test_resolve_dtype_uses_float32_without_cuda(self):
+        self.assertEqual(resolve_torch_dtype(FakeTorch(cuda_available=False), env={}), "float32")
+
+    def test_resolve_dtype_respects_override(self):
+        torch_module = FakeTorch(cuda_available=True)
+        self.assertEqual(resolve_torch_dtype(torch_module, env={"FINGPT_TORCH_DTYPE": "fp32"}), "float32")
+        self.assertEqual(resolve_torch_dtype(torch_module, env={"FINGPT_TORCH_DTYPE": "bf16"}), "bfloat16")
+
+    def test_resolve_dtype_rejects_unknown_override(self):
+        with self.assertRaisesRegex(ValueError, "FINGPT_TORCH_DTYPE"):
+            resolve_torch_dtype(FakeTorch(cuda_available=True), env={"FINGPT_TORCH_DTYPE": "fp15"})
+
+    def test_print_gpu_utilization_skips_cpu_only_runtime(self):
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            printed = print_gpu_utilization(FakeTorch(cuda_available=False), nvml_module=FakeNvml())
+
+        self.assertFalse(printed)
+        self.assertIn("CUDA is not available", stdout.getvalue())
+
+    def test_print_gpu_utilization_handles_nvml_failure(self):
+        class BrokenNvml(FakeNvml):
+            def nvmlInit(self):
+                raise RuntimeError("NVML Shared Library Not Found")
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            printed = print_gpu_utilization(FakeTorch(cuda_available=True), nvml_module=BrokenNvml())
+
+        self.assertFalse(printed)
+        self.assertIn("GPU memory report unavailable", stdout.getvalue())
+
+    def test_print_gpu_utilization_reports_and_shuts_down_nvml(self):
+        nvml = FakeNvml()
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            printed = print_gpu_utilization(FakeTorch(cuda_available=True), nvml_module=nvml)
+
+        self.assertTrue(printed)
+        self.assertTrue(nvml.shutdown_called)
+        self.assertIn("GPU memory occupied: 512 MB.", stdout.getvalue())
+
+    def test_empty_cuda_cache_only_when_cuda_is_available(self):
+        gpu_torch = FakeTorch(cuda_available=True)
+        cpu_torch = FakeTorch(cuda_available=False)
+
+        empty_cuda_cache(gpu_torch)
+        empty_cuda_cache(cpu_torch)
+
+        self.assertTrue(gpu_torch.cuda.empty_cache_called)
+        self.assertFalse(cpu_torch.cuda.empty_cache_called)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- choose `float16` only when CUDA is available and default to `float32` on CPU-only runtimes
- make GPU memory reporting tolerant of missing CUDA/NVML instead of failing the app import path
- add `FINGPT_TORCH_DTYPE` override support with explicit validation, plus unit coverage for dtype resolution, NVML handling, and CUDA cache cleanup

## Why this matters
The Forecaster demo currently assumes CUDA fp16/NVML availability. That can break local CPU-only or Windows smoke tests before users reach the actual forecasting flow. Keeping runtime hardware checks best-effort, while failing fast on invalid explicit dtype overrides, makes the demo easier to validate without changing the model path for CUDA users.

## Scope
This addresses the NVML and CPU fp16 runtime failure patterns reported in #119 without changing model loading, prompts, market data access, or generated forecasting behavior.

## Validation
- `python -m pytest fingpt\FinGPT_Forecaster\tests\test_runtime_utils.py -q` - 8 passed
- `git diff --check` - clean
- Full Gradio/model inference was not run because it requires Hugging Face credentials, the Llama-2 base model, LoRA weights, and market data API keys.