### PR TITLE
Add support for news content datasets in fine-tuning and document dataset usage

### DIFF
--- a/fingpt/FinGPT_Benchmark/readme.md
+++ b/fingpt/FinGPT_Benchmark/readme.md
@@ -58,6 +58,10 @@ We use different datasets at different phases of our instruction tuning paradigm
 - Multi-task Instruction Tuning: `sentiment-train & finred & ner & headline`
 - Zero-shot Aimed Instruction Tuning: `finred-cls & ner-cls & headline-cls -> sentiment-cls (test)`
 
+In our benchmark experiments, we used the headline dataset for sentiment fine-tuning because it was the most practical option for time and token-budget reasons. The news content dataset was kept in the data preparation pipeline, but it was not used in the final benchmark runs.
+
+If you want to experiment further, you can extend the preprocessing step to combine headlines and news content, or use the content split as a separate training source.
+
 You may download the datasets according to your needs. We also provide processed datasets for ConvFinQA and FinEval, but they are not used in our final work.
 
 ### prepare data from scratch

--- a/fingpt/FinGPT_Benchmark/train_lora.py
+++ b/fingpt/FinGPT_Benchmark/train_lora.py
@@ -71,17 +71,32 @@ def main(args):
     
     # Load training and testing datasets
     dataset_list = load_dataset(args.dataset, args.from_remote)
-    dataset_train = datasets.concatenate_datasets([d['train'] for d in dataset_list]).shuffle(seed=42)
+    mode = args.input_mode
+
+    def prepare_example(example):
+        if mode == "headline":
+            example["input"] = example["headline"]
+        elif mode == "content":
+            example["input"] = example["content"]
+        elif mode == "both":
+            example["input"] = f"Headline: {example['headline']}\nContent: {example['content']}"
+        else:
+            raise ValueError(f"invalid input_mode: {mode}")
+        return example
     
+    dataset_train = datasets.concatenate_datasets([d['train'] for d in dataset_list]).shuffle(seed=42)
+
     if args.test_dataset:
         dataset_list = load_dataset(args.test_dataset, args.from_remote)
     dataset_test = datasets.concatenate_datasets([d['test'] for d in dataset_list])
+
+    dataset = datasets.DatasetDict({"train": dataset_train, "test": dataset_test})
+    dataset = dataset.map(prepare_example)
+    dataset = dataset.map(partial(tokenize, args, tokenizer))
     
-    dataset = datasets.DatasetDict({'train': dataset_train, 'test': dataset_test})
     # Display first sample from the training dataset
     print(dataset['train'][0])
     # Filter out samples that exceed the maximum token length and remove unused columns
-    dataset = dataset.map(partial(tokenize, args, tokenizer))
     print('original dataset length: ', len(dataset['train']))
     dataset = dataset.filter(lambda x: not x['exceed_max_length'])
     print('filtered dataset length: ', len(dataset['train']))
@@ -172,6 +187,7 @@ if __name__ == "__main__":
     parser.add_argument("--local_rank", default=0, type=int)
     parser.add_argument("--run_name", default='local-test', type=str)
     parser.add_argument("--dataset", required=True, type=str)
+    parser.add_argument("--input_mode", default="headline", type=str, choices=["headline", "content", "both"])
     parser.add_argument("--test_dataset", type=str)
     parser.add_argument("--base_model", required=True, type=str, choices=['chatglm2', 'llama2', 'llama2-13b', 'llama2-13b-nr', 'baichuan', 'falcon', 'internlm', 'qwen', 'mpt', 'bloom'])
     parser.add_argument("--max_length", default=512, type=int)


### PR DESCRIPTION
- Add --input_mode argument to train_lora.py with choices: headline, content, both
- Add prepare_example function to handle different input modes for dataset processing
- Update readme.md to explain why headline datasets were used in benchmark experiments
- Document that content datasets are available for users who want to experiment further
- Fix dataset processing flow to properly apply input mode transformations

This addresses issue #68 by clarifying the role of news content datasets and providing the infrastructure to use them in fine-tuning.

Closes #68