### PR TITLE
Fix #204: Fix tfns.py to generate proper sentiment labels

### DIFF
--- a/fingpt/FinGPT_Benchmark/benchmarks/tfns.py
+++ b/fingpt/FinGPT_Benchmark/benchmarks/tfns.py
@@ -62,7 +62,8 @@ def test_tfns(args, model, tokenizer, prompt_fun=None):
         # tokens.pop('token_type_ids')
         for k in tokens.keys():
             tokens[k] = tokens[k].cuda()
-        res = model.generate(**tokens, max_length=512, eos_token_id=tokenizer.eos_token_id)
+        res = model.generate(**tokens, do_sample=False, max_length=512,
+                             eos_token_id=tokenizer.eos_token_id, max_new_tokens=10)
         res_sentences = [tokenizer.decode(i, skip_special_tokens=True) for i in res]
         out_text = [o.split("Answer: ")[1] for o in res_sentences]
         out_text_list += out_text


### PR DESCRIPTION
## Problem
The tfns benchmark was generating empty strings and random numbers instead of proper sentiment labels (positive/negative/neutral).

## Solution
Added `do_sample=False` and `max_new_tokens=10` to the `model.generate()` call in `tfns.py` to match the working pattern used in other benchmark files.

## Change
```python
# Added these parameters to line 65:
do_sample=False, max_new_tokens=10
```

# Issues
Closes #204