### PR TITLE
Fix issue #269 Triton runtime import error

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -412,13 +412,13 @@ pip install -r requirements.txt --force-reinstall
 
 **Solution**: This occurs when using incompatible triton versions with bitsandbytes on NVIDIA GPU systems.
 ```bash
-# For NVIDIA GPU systems (Linux/Windows)
-pip install triton<2.1.0
-# Or downgrade triton if already installed
-pip install triton==2.0.1
+# For NVIDIA GPU systems (Linux x86_64)
+pip install "bitsandbytes>=0.43.1" "triton<3.0.0"
+# Reinstall both packages if an incompatible version is already installed
+pip install --upgrade --force-reinstall "bitsandbytes>=0.43.1" "triton<3.0.0"
 ```
 
-**Note**: On macOS/M1 systems, triton is not required or available. Skip triton installation and use Apple's Metal Performance Shaders (MPS) for GPU acceleration instead.
+**Note**: Triton is only declared for Linux x86_64 GPU environments. On macOS/M1 systems, skip Triton and use Apple's Metal Performance Shaders (MPS) for GPU acceleration instead.
 
 #### Issue 8: NumPy 2.x Compatibility
 **Problem**: `A module that was compiled using NumPy 1.x cannot be run in NumPy 2.x`

--- a/fingpt/FinGPT_Forecaster/requirements.txt
+++ b/fingpt/FinGPT_Forecaster/requirements.txt
@@ -1,9 +1,9 @@
 torch==2.0.1
 transformers==4.32.0
 peft==0.5.0
-bitsandbytes==0.41.1
+bitsandbytes>=0.43.1
 accelerate==0.23.0
-# triton<2.1.0  # Required for bitsandbytes compatibility on NVIDIA GPUs only
+triton<3.0.0; platform_system == "Linux" and platform_machine == "x86_64"
 gradio==3.50.2
 pandas
 yfinance

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ sentencepiece
 accelerate
 torch
 datasets
-bitsandbytes
-
 # ML dependencies (for GPU acceleration compatibility)
-# triton<2.1.0  # Required for bitsandbytes compatibility on NVIDIA GPUs only
+bitsandbytes>=0.43.1
+# Triton is installed separately for supported NVIDIA GPU environments.


### PR DESCRIPTION
## Description
Resolves the `ModuleNotFoundError: No module named 'triton.runtime'` crash that occurs when loading dependencies (specifically `bitsandbytes` / `transformers` / `peft`) during inference or fine-tuning in `FinGPT_Forecaster`. 

The error arises due to an incompatible Triton build / runtime dependency mismatch (or when running on platforms where Triton is not supported or requires specific pinned wheel/runtime versions).

### Changes
- Updated `requirements.txt` and `fingpt/FinGPT_Forecaster/requirements.txt` to align package versions, ensuring compatible installs of `torch`, `transformers`, `peft`, and `bitsandbytes`.
- Updated `SETUP.md` with explicit environment setup notes and troubleshooting instructions for the Triton runtime dependency.

### How Has This Been Tested?
- Verified clean package installation from the updated `requirements.txt`.
- Confirmed that running `FinGPT_Forecaster` initializes and imports without triggering `ModuleNotFoundError: No module named 'triton.runtime'`.

### Related Issue
Closes #269