### PR TITLE
Fix issue #165: Update deprecated prepare_model_for_int8_training to prepare_model_for_kbit_training in ChatGLM2 LoRA notebook

### DIFF
--- a/FinGPT_Training_LoRA_with_ChatGLM2_6B_for_Beginners.ipynb
+++ b/FinGPT_Training_LoRA_with_ChatGLM2_6B_for_Beginners.ipynb
@@ -1110,7 +1110,6 @@
         "    get_peft_model,\n",
         "    set_peft_model_state_dict,\n",
         "    prepare_model_for_kbit_training,\n",
-        "    prepare_model_for_int8_training,\n",
         ")\n",
         "from peft.utils import TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING"
       ]
@@ -1466,9 +1465,9 @@
         "        model_name,\n",
         "        quantization_config=q_config,\n",
         "        trust_remote_code=True,\n",
-        "        device='cuda'\n",
+        "        device_map=\"auto\"\n",
         "    )\n",
-        "model = prepare_model_for_int8_training(model, use_gradient_checkpointing=True)"
+        "model = prepare_model_for_kbit_training(model, use_gradient_checkpointing=True)"
       ]
     },
     {


### PR DESCRIPTION
## Description
Resolves the `ImportError` / crash encountered when running `FinGPT_Training_LoRA_with_ChatGLM2_6B_for_Beginners.ipynb`:
1. Replaces the deprecated `prepare_model_for_int8_training` method with `prepare_model_for_kbit_training` from `peft`.
2. Updates `device='cuda'` to `device_map="auto"` when initializing `AutoModel.from_pretrained` with `quantization_config`, aligning with modern Hugging Face `accelerate` quantization requirements.

### Changes
- `FinGPT_Training_LoRA_with_ChatGLM2_6B_for_Beginners.ipynb`:
  - Removed deprecated `prepare_model_for_int8_training` import in Cell #26.
  - Updated model loading to `device_map="auto"` and called `prepare_model_for_kbit_training` in Cell #31.

### Testing
- Verified notebook JSON structure and diff cleanliness.
- Confirmed compatibility of the updated method calls against modern `peft` and `transformers`.

### Related Issue
Closes #165