### PR TITLE
Add Docker support for FinGPT Forecaster

### DIFF
--- a/fingpt/FinGPT_Forecaster/.dockerignore
+++ b/fingpt/FinGPT_Forecaster/.dockerignore
@@ -1,0 +1,9 @@
+*.ipynb
+.env
+.env.*
+__pycache__
+.pytest_cache
+offload
+AAAI-Good-Data
+figs
+.git

--- a/fingpt/FinGPT_Forecaster/Dockerfile
+++ b/fingpt/FinGPT_Forecaster/Dockerfile
@@ -1,0 +1,21 @@
+FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    HF_HOME=/models
+
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip git && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install -r requirements.txt
+
+COPY . .
+
+EXPOSE 7860
+
+CMD ["python3", "app.py"]

--- a/fingpt/FinGPT_Forecaster/README.md
+++ b/fingpt/FinGPT_Forecaster/README.md
@@ -51,6 +51,20 @@ For HuggingFace Space deployment, set these secrets in your Space settings:
 
 We have released our FinGPT-Forecaster trained on DOW30 market data from 2022-12-30 to 2023-9-1 on HuggingFace: [fingpt-forecaster_dow30_llama2-7b_lora](https://huggingface.co/FinGPT/fingpt-forecaster_dow30_llama2-7b_lora)
 
+### Run with Docker
+
+Docker Desktop users can build and run the Forecaster with:
+
+```bash
+docker build --platform linux/amd64 -t fingpt-forecaster .
+docker run --rm --platform linux/amd64 \
+    --env-file .env \
+    -p 7860:7860 \
+    fingpt-forecaster
+```
+
+Open <http://localhost:7860> after the container starts. The `.env` file must define `HF_TOKEN` and `FINNHUB_API_KEY`; it is excluded from the Docker build context.
+
 We have most of the key requirements in `requirements.txt`. Before you start, do `pip install -r requirements.txt`. Then you can refer to `demo.ipynb` for our deployment and evaluation script.
 
 First let's load the model:

--- a/fingpt/FinGPT_Forecaster/requirements.txt
+++ b/fingpt/FinGPT_Forecaster/requirements.txt
@@ -1,12 +1,12 @@
 torch==2.0.1
 transformers==4.32.0
 peft==0.5.0
-bitsandbytes>=0.43.1
+bitsandbytes==0.43.1
 accelerate==0.23.0
 triton<3.0.0; platform_system == "Linux" and platform_machine == "x86_64"
 gradio==3.50.2
 pandas
-yfinance
+yfinance==0.2.49
 finnhub-python
 nvidia-ml-py3
 requests


### PR DESCRIPTION
## Summary

- Add Docker support for the FinGPT Forecaster
- Pin yfinance to 0.2.49 to resolve the websockets.asyncio import issue
- Exclude environment files and build artifacts from the Docker context
- Document Docker build and run instructions

## Testing

- Verified the Docker image builds and runs successfully
- Verified the Gradio UI is reachable on port 7860
- Verified the dependency imports
- Verified .env is excluded from the Docker build context
- Ran Python syntax and whitespace checks

Closes #92 