### PR TITLE
feat: add A-share factor report evaluator

### DIFF
--- a/fingpt/FinGPT_Benchmark/benchmarks/ashare_factor.py
+++ b/fingpt/FinGPT_Benchmark/benchmarks/ashare_factor.py
@@ -1,0 +1,86 @@
+"""Evaluate the structure of A-share factor research outputs.
+
+The evaluator intentionally does not claim that a recommendation is correct.
+It checks whether a report contains the fields needed for reproducible review.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+
+RECOMMENDATIONS = {"buy", "hold", "sell"}
+REQUIRED_FIELDS = {"symbol", "as_of", "factors", "risks", "recommendation", "confidence"}
+
+
+def evaluate_record(record):
+    """Return structural metrics and validation errors for one report."""
+    errors = []
+    if not isinstance(record, dict):
+        return {"valid": False, "score": 0.0, "errors": ["record must be an object"]}
+
+    missing = sorted(REQUIRED_FIELDS - record.keys())
+    errors.extend(f"missing field: {field}" for field in missing)
+
+    factors = record.get("factors")
+    if not isinstance(factors, list) or not factors:
+        errors.append("factors must be a non-empty list")
+    else:
+        for index, factor in enumerate(factors):
+            if not isinstance(factor, dict):
+                errors.append(f"factors[{index}] must be an object")
+                continue
+            for field in ("name", "direction", "evidence"):
+                if not factor.get(field):
+                    errors.append(f"factors[{index}] missing field: {field}")
+
+    risks = record.get("risks")
+    if not isinstance(risks, list) or not risks:
+        errors.append("risks must be a non-empty list")
+
+    if record.get("recommendation") not in RECOMMENDATIONS:
+        errors.append("recommendation must be buy, hold, or sell")
+
+    confidence = record.get("confidence")
+    if not isinstance(confidence, (int, float)) or isinstance(confidence, bool) or not 0 <= confidence <= 1:
+        errors.append("confidence must be a number between 0 and 1")
+
+    score = 1.0 - min(len(errors), 5) / 5
+    return {"valid": not errors, "score": round(score, 3), "errors": errors}
+
+
+def evaluate_file(path):
+    """Evaluate newline-delimited JSON reports and return aggregate metrics."""
+    results = []
+    with Path(path).open(encoding="utf-8") as stream:
+        for line_number, line in enumerate(stream, 1):
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+                result = evaluate_record(record)
+            except json.JSONDecodeError as error:
+                result = {"valid": False, "score": 0.0, "errors": [f"invalid JSON: {error.msg}"]}
+            result["line"] = line_number
+            results.append(result)
+
+    if not results:
+        raise ValueError("input file contains no JSON records")
+
+    return {
+        "records": len(results),
+        "valid_records": sum(result["valid"] for result in results),
+        "mean_score": round(sum(result["score"] for result in results) / len(results), 3),
+        "results": results,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("reports", type=Path, help="newline-delimited JSON report file")
+    args = parser.parse_args()
+    print(json.dumps(evaluate_file(args.reports), ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/fingpt/FinGPT_Benchmark/readme.md
+++ b/fingpt/FinGPT_Benchmark/readme.md
@@ -170,4 +170,32 @@ CUDA_VISIBLE_DEVICES=1 python benchmarks.py \
 For Zero-shot Evaluation on Sentiment Analysis, we use multiple prompts and evaluate each of them.
 The task indicators are `fiqa_mlt` and `fpb_mlt`.
 
+## A-share Factor Research Reports
+
+`benchmarks/ashare_factor.py` checks the structure of newline-delimited JSON
+research reports. It is intentionally independent of model inference and
+market-data providers, so it can be used as a first-pass quality gate before
+human or backtest evaluation.
+
+Each report must contain `symbol`, `as_of`, `factors`, `risks`,
+`recommendation`, and `confidence`. Every factor must contain `name`,
+`direction`, and `evidence`; `recommendation` must be `buy`, `hold`, or
+`sell`; and `confidence` must be between 0 and 1.
+
+Example record:
+
+```json
+{"symbol":"600000.SH","as_of":"2026-01-01","factors":[{"name":"earnings","direction":"positive","evidence":"revenue growth"}],"risks":["valuation"],"recommendation":"buy","confidence":0.8}
+```
+
+Run the evaluator with:
+
+```bash
+python benchmarks/ashare_factor.py reports.jsonl
+```
+
+The output includes per-record validation errors, the number of valid reports,
+and the mean structural score. This score measures report completeness, not
+investment performance or recommendation accuracy.
+
 

--- a/tests/test_ashare_factor_benchmark.py
+++ b/tests/test_ashare_factor_benchmark.py
@@ -1,0 +1,52 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).parents[1]
+    / "fingpt"
+    / "FinGPT_Benchmark"
+    / "benchmarks"
+    / "ashare_factor.py"
+)
+SPEC = importlib.util.spec_from_file_location("ashare_factor", MODULE_PATH)
+ashare_factor = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ashare_factor)
+
+
+class AShareFactorBenchmarkTests(unittest.TestCase):
+    def setUp(self):
+        self.valid_record = {
+            "symbol": "600000.SH",
+            "as_of": "2026-01-01",
+            "factors": [
+                {
+                    "name": "earnings",
+                    "direction": "positive",
+                    "evidence": "revenue growth",
+                }
+            ],
+            "risks": ["valuation"],
+            "recommendation": "buy",
+            "confidence": 0.8,
+        }
+
+    def test_complete_record_is_valid(self):
+        result = ashare_factor.evaluate_record(self.valid_record)
+
+        self.assertTrue(result["valid"])
+        self.assertEqual(result["score"], 1.0)
+        self.assertEqual(result["errors"], [])
+
+    def test_invalid_confidence_is_reported(self):
+        record = dict(self.valid_record, confidence=1.2)
+
+        result = ashare_factor.evaluate_record(record)
+
+        self.assertFalse(result["valid"])
+        self.assertIn("confidence must be a number between 0 and 1", result["errors"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a dependency-free evaluator for the structure of A-share factor research reports.

## Changes

- Add JSONL report validation for:
  - factors and supporting evidence
  - risks
  - recommendation
  - confidence score
- Add aggregate structural metrics and per-record errors.
- Document the report schema and CLI usage.
- Add regression tests for valid and invalid reports.

## Validation

- `python -m unittest tests/test_ashare_factor_benchmark.py`
- `python -m py_compile fingpt/FinGPT_Benchmark/benchmarks/ashare_factor.py tests/test_ashare_factor_benchmark.py`

This measures report completeness, not investment performance or recommendation accuracy.

Closes #249.